### PR TITLE
Add tele.ch - Init7 mapping for ITV 1 HD

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,6 +116,8 @@ def match_tele(channel_list, tele_epg):
             channel_id = "rts1"
         elif channel_id == "rtsdeux":
             channel_id = "rts2"
+        elif channel_id == "itv":
+            channel_id = "itv1"
 
         if find_channel_by_id(channel_id, channel_list):
             programm_matched = {


### PR DESCRIPTION
Tele.ch's id is `itv`. Init7's id after the prep step is `itv1`.

```bash
$ curl https://api.init7.net/tvchannels.m3u -s | grep "ITV 1"
#EXTINF:-1,ITV 1 HD
```

This block of `ifselse`s should probably be represented with a dict and put aside.

:gb: 