### PR TITLE
Continue processing other sources on error

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,11 +36,19 @@ def __main__():
     channels = get_channel_list()
 
     print("[*] Getting EPG data from teleboy.ch")
-    teleboy_raw = teleboy.get_epg_by_duration(7 * 24 * 60)
+    teleboy_raw = ""
+    try:
+        teleboy_raw = teleboy.get_epg_by_duration(7 * 24 * 60)
+    except:
+        print("[*] Failed. Continue processing other sources.")
     teleboy_epg = match_teleboy_epg(channels, teleboy_raw)
 
     print("[*] Getting EPG data from tele.ch")
-    tele_raw = tele.get_epg_by_duration(7 * 24 * 60)
+    tele_raw = ""
+    try:
+        tele_raw = tele.get_epg_by_duration(7 * 24 * 60)
+    except:
+        print("[*] Failed. Continue processing other sources.")
     tele_epg = match_tele_epg(channels, tele_raw)
 
     # generate the xml for the channels


### PR DESCRIPTION
Continues processing other sources on error of one source.

This is what it will look like, shortened sample with `get_epg_by_duration(1 * 1 * 60)`:

```sh
[*] Getting/parsing Init7 tvchannels.m3u playlist
[*] Getting EPG data from teleboy.ch
[*] Dowloading from 2021-01-13T09:18:39.812992 until 2021-01-13T09:48:39.812992
[*] Dowloading from 2021-01-13T09:48:39.812992 until 2021-01-13T10:18:39.812992
[*] Dowloading from 2021-01-13T10:18:39.812992 until 2021-01-13T10:48:39.812992
[*] Matching teleboy.ch EPG data (900 programms to 200 channels)
[✓] Matched 141 teleboy.ch channels
[*] Getting EPG data from tele.ch
[*] Downloading from 2021-01-13T09:18:42.362355 until 2021-01-13T10:18:42.362355
[*] Failed. Continue processing.
[*] Matching tele.ch EPG data (0 programms to 200 channels)
[✓] Matched 0 tele.ch channels
[*] Generating XML for 200 channels
[*] Generating XML for 529 programms
[*] Generating XML for 0 programms
[*] Generating XML for 529 programms
```

Relates https://github.com/mathewmeconry/TV7_EPG_Data/issues/6.