### PR TITLE
Fix to introduced error in XML output

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ def programms_to_xmltv(programms):
 
         programm_xml = ""
         programm_xml = (f"{programm_xml}<programme start=\""
-                    f"{programm['start'].strftime('%Y%m%d%H%M%S %z')}\"" 
+                    f"{programm['start'].strftime('%Y%m%d%H%M%S %z')}\" " 
                     f"stop=\"{programm['stop'].strftime('%Y%m%d%H%M%S %z')}\" channel=\"{programm['channel']}\">")
 
         programm_xml = f"{programm_xml}<icon src=\"{programm['icon']}\" />"


### PR DESCRIPTION
Missing a space in the output xml before 'stop' parameter.

Have checked that all other produced xml is valid and it now looks to be after this fix.