### PR TITLE
Fix: program orphans

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,10 @@ def get_channel_list():
                     channel_obj["display_name"]
                 )
 
-            channel_list.append(channel_obj)
+            if any(x["id"] == channel_obj["id"] for x in channel_list):
+                print(f"[!] Duplicate channel: {channel_obj['id']}")
+            else:
+                channel_list.append(channel_obj)
 
     return channel_list
 

--- a/main.py
+++ b/main.py
@@ -234,7 +234,7 @@ def programms_to_xmltv(programms):
         programm_xml = (
             f'{programm_xml}<programme start="'
             f"{programm['start'].strftime('%Y%m%d%H%M%S %z')}\" "
-            f"stop=\"{programm['stop'].strftime('%Y%m%d%H%M%S %z')}\" channel=\"{programm['channel']}\">"
+            f"stop=\"{programm['stop'].strftime('%Y%m%d%H%M%S %z')}\" channel=\"{gen_channel_id_from_name(programm['channel'])}\">"
         )
 
         if "title" in programm:


### PR DESCRIPTION
Jellyfin does not integrate the generated `tv7_init7_epg.xml` file.
It seems to be due to duplicated channel-ids and / or due to not mapped XML-channels.
The programs must refer to the channel-id which seems not to be the same in a channel and a program.

When running the script, I get the following duplicated channel-id: `bbcone` (coming from BBC One & BBC One (hd) I assume).
I also got 0 correctly mapped programs and 126435 not correctly mapped,

Performance wise it could definitely be improved, but since this script probably runs once a week, I think this can be omitted for now.

With these changes, I can import the file in Jellyfin.